### PR TITLE
Add unit tests for services and middleware

### DIFF
--- a/GerenciaPedidos.Tests/ExceptionMiddlewareTest.cs
+++ b/GerenciaPedidos.Tests/ExceptionMiddlewareTest.cs
@@ -1,0 +1,74 @@
+using GerenciaPedidos.Application.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GerenciaPedidos.Tests
+{
+    public class ExceptionMiddlewareTest
+    {
+        private readonly Mock<RequestDelegate> _nextMock;
+        private readonly Mock<ILogger<ExceptionMiddleware>> _loggerMock;
+        private readonly ExceptionMiddleware _middleware;
+
+        public ExceptionMiddlewareTest()
+        {
+            _nextMock = new Mock<RequestDelegate>();
+            _loggerMock = new Mock<ILogger<ExceptionMiddleware>>();
+            _middleware = new ExceptionMiddleware(_nextMock.Object, _loggerMock.Object);
+        }
+
+        [Fact]
+        public async Task Test_InvokeAsync_ShouldHandleValidationException()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            _nextMock.Setup(next => next(It.IsAny<HttpContext>())).Throws(new ValidationException("Validation error"));
+
+            // Act
+            await _middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
+            _loggerMock.Verify(logger => logger.LogError(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Test_InvokeAsync_ShouldHandleKeyNotFoundException()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            _nextMock.Setup(next => next(It.IsAny<HttpContext>())).Throws(new KeyNotFoundException("Not found"));
+
+            // Act
+            await _middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.NotFound, context.Response.StatusCode);
+            _loggerMock.Verify(logger => logger.LogError(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Test_InvokeAsync_ShouldHandleGeneralException()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            _nextMock.Setup(next => next(It.IsAny<HttpContext>())).Throws(new Exception("General error"));
+
+            // Act
+            await _middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.InternalServerError, context.Response.StatusCode);
+            _loggerMock.Verify(logger => logger.LogError(It.IsAny<string>()), Times.Once);
+        }
+    }
+}

--- a/GerenciaPedidos.Tests/OrderServiceTests.cs
+++ b/GerenciaPedidos.Tests/OrderServiceTests.cs
@@ -1,0 +1,116 @@
+using GerenciaPedidos.Application.DTOs;
+using GerenciaPedidos.Application.Services;
+using GerenciaPedidos.Domain.Entities;
+using GerenciaPedidos.Domain.Repositories;
+using Moq;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GerenciaPedidos.Tests
+{
+    public class OrderServiceTests
+    {
+        private readonly Mock<IOrderRepository> _orderRepositoryMock;
+        private readonly Mock<IProductRepository> _productRepositoryMock;
+        private readonly OrderService _orderService;
+
+        public OrderServiceTests()
+        {
+            _orderRepositoryMock = new Mock<IOrderRepository>();
+            _productRepositoryMock = new Mock<IProductRepository>();
+            _orderService = new OrderService(_orderRepositoryMock.Object, _productRepositoryMock.Object);
+        }
+
+        [Fact]
+        public async Task Test_CreateOrderAsync_ShouldCreateOrder()
+        {
+            // Arrange
+            var createOrderDTO = new CreateOrderDTO
+            {
+                Description = "Test Order",
+                ProductsIds = new List<int> { 1 },
+                Quantities = new List<int> { 2 }
+            };
+
+            var product = new Product("Test Product", 10, 5);
+            _productRepositoryMock.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(product);
+
+            // Act
+            var result = await _orderService.CreateOrderAsync(createOrderDTO);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test Order", result.Description);
+            Assert.Single(result.Products);
+            Assert.Equal(20, result.TotalValue);
+        }
+
+        [Fact]
+        public async Task Test_GetAllAsync_ShouldReturnAllOrders()
+        {
+            // Arrange
+            var orders = new List<Order>
+            {
+                new Order("Order 1"),
+                new Order("Order 2")
+            };
+
+            _orderRepositoryMock.Setup(repo => repo.GetAllAsync(2, 0)).ReturnsAsync(orders);
+
+            // Act
+            var result = await _orderService.GetAllAsync(2, 0);
+
+            // Assert
+            Assert.Equal(2, result.Count());
+        }
+
+        [Fact]
+        public async Task Test_GetOrdersByStatusAsync_ShouldReturnOrdersByStatus()
+        {
+            // Arrange
+            var orders = new List<Order>
+            {
+                new Order("Order 1") { Open = true },
+                new Order("Order 2") { Open = false }
+            };
+
+            _orderRepositoryMock.Setup(repo => repo.GetOrdersByStatusAsync(true, 0, 2)).ReturnsAsync(orders.Where(o => o.Open));
+
+            // Act
+            var result = await _orderService.GetOrdersByStatusAsync(true, 2, 0);
+
+            // Assert
+            Assert.Single(result);
+            Assert.True(result.First().Open);
+        }
+
+        [Fact]
+        public async Task Test_UpdateAsync_ShouldUpdateOrder()
+        {
+            // Arrange
+            var createOrderDTO = new CreateOrderDTO
+            {
+                Description = "Updated Order",
+                ProductsIds = new List<int> { 1 },
+                Quantities = new List<int> { 2 }
+            };
+
+            var order = new Order("Test Order");
+            var product = new Product("Test Product", 10, 5);
+
+            _orderRepositoryMock.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(order);
+            _productRepositoryMock.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(product);
+
+            // Act
+            var result = await _orderService.UpdateAsync(createOrderDTO, 1);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Updated Order", result.Description);
+            Assert.Single(result.Products);
+            Assert.Equal(20, result.TotalValue);
+        }
+    }
+}

--- a/GerenciaPedidos.Tests/ProductServiceTests.cs
+++ b/GerenciaPedidos.Tests/ProductServiceTests.cs
@@ -1,0 +1,68 @@
+using GerenciaPedidos.Application.DTOs;
+using GerenciaPedidos.Application.Services;
+using GerenciaPedidos.Domain.Entities;
+using GerenciaPedidos.Domain.Repositories;
+using Moq;
+using Xunit;
+
+namespace GerenciaPedidos.Tests
+{
+    public class ProductServiceTests
+    {
+        private readonly Mock<IOrderRepository> _mockOrderRepository;
+        private readonly Mock<IProductRepository> _mockProductRepository;
+        private readonly ProductService _productService;
+
+        public ProductServiceTests()
+        {
+            _mockOrderRepository = new Mock<IOrderRepository>();
+            _mockProductRepository = new Mock<IProductRepository>();
+            _productService = new ProductService(_mockOrderRepository.Object, _mockProductRepository.Object);
+        }
+
+        [Fact]
+        public async Task Test_CreateProductAsync_ShouldCreateProduct()
+        {
+            // Arrange
+            var createProductDTO = new CreateProductDTO
+            {
+                Name = "Test Product",
+                Value = 10.0m,
+                Stock = 5
+            };
+
+            var product = new Product(createProductDTO.Name, createProductDTO.Value, createProductDTO.Stock);
+
+            _mockProductRepository.Setup(repo => repo.AddAsync(It.IsAny<Product>())).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _productService.CreateProductAsync(createProductDTO);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(createProductDTO.Name, result.Name);
+            Assert.Equal(createProductDTO.Value, result.Value);
+            Assert.Equal(createProductDTO.Stock, result.Stock);
+        }
+
+        [Fact]
+        public async Task Test_GetAllAsync_ShouldReturnAllProducts()
+        {
+            // Arrange
+            var products = new List<Product>
+            {
+                new Product("Product 1", 10.0m, 5),
+                new Product("Product 2", 20.0m, 10)
+            };
+
+            _mockProductRepository.Setup(repo => repo.GetAllAsync(It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(products);
+
+            // Act
+            var result = await _productService.GetAllAsync(10, 0);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests for OrderService, ProductService, and ExceptionMiddleware.

* **OrderServiceTests.cs**
  - Create `OrderServiceTests` class.
  - Add tests for `CreateOrderAsync`, `GetAllAsync`, `GetOrdersByStatusAsync`, and `UpdateAsync` methods.

* **ProductServiceTests.cs**
  - Create `ProductServiceTests` class.
  - Add tests for `CreateProductAsync` and `GetAllAsync` methods.

* **ExceptionMiddlewareTest.cs**
  - Create `ExceptionMiddlewareTest` class.
  - Add tests for `InvokeAsync` method handling `ValidationException`, `KeyNotFoundException`, and general `Exception`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/guilhermecso/GerenciaPedidos/pull/1?shareId=b5e098c6-3429-4729-82bd-5959dd7e3634).